### PR TITLE
Update version to 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ Here is how to build it:
 
 To to fill in the source database, run **sync-files-database** example first:
 
-    java -jar sync-files-database/target/sync-files-database-1.0-SNAPSHOT.jar --config=sync-files-database/config.yml --exec --job=sync
+    java -jar sync-files-database/target/sync-files-database-2.0.jar --config=sync-files-database/config.yml --exec --job=sync
 
 Then run **sync-database**:
 
-    java -jar sync-database/target/sync-database-1.0-SNAPSHOT.jar --config=sync-database/config.yml --exec --job=sync
+    java -jar sync-database/target/sync-database-2.0.jar --config=sync-database/config.yml --exec --job=sync
 
    
 **Note:** more detailed explanations you can find in the README.md of the examples.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.bootique.linkmove.demo</groupId>
     <artifactId>bootique-linkmove-demo</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0</version>
     <packaging>pom</packaging>
 
     <name>bootique-linkmove-demo</name>

--- a/sync-database/README.md
+++ b/sync-database/README.md
@@ -22,7 +22,7 @@ Here is how to build it:
 
 Check the options available in your app:
 
-    java -jar sync-database/target/sync-database-1.0-SNAPSHOT.jar
+    java -jar sync-database/target/sync-database-2.0.jar
 
     OPTIONS
       -c yaml_location, --config=yaml_location
@@ -103,7 +103,7 @@ Transforming data is performed by extractors described in XML (e.g. [domain-extr
 
 Run the job:
     
-    java -jar sync-database/target/sync-database-1.0-SNAPSHOT.jar --config=sync-database/config.yml --exec --job=sync
+    java -jar sync-database/target/sync-database-2.0.jar --config=sync-database/config.yml --exec --job=sync
 
 Result report:
 

--- a/sync-database/pom.xml
+++ b/sync-database/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bootique-linkmove-demo</artifactId>
         <groupId>io.bootique.linkmove.demo</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>io.bootique.bom</groupId>
                 <artifactId>bootique-bom</artifactId>
-                <version>1.0.RC1</version>
+                <version>2.0-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/sync-database/src/main/java/Application.java
+++ b/sync-database/src/main/java/Application.java
@@ -1,9 +1,9 @@
-import com.google.inject.Binder;
-import com.google.inject.Module;
+import io.bootique.BaseModule;
 import io.bootique.Bootique;
+import io.bootique.di.Binder;
 import io.bootique.job.runtime.JobModule;
 
-public class Application implements Module {
+public class Application extends BaseModule {
 
     public static void main(String[] args) {
         Bootique.app(args)

--- a/sync-files-database/README.md
+++ b/sync-files-database/README.md
@@ -22,7 +22,7 @@ Here is how to build it:
 
 Check the options available in your app:
 
-    java -jar sync-files-database/target/sync-files-database-1.0-SNAPSHOT.jar
+    java -jar sync-files-database/target/sync-files-database-2.0.jar
 
     OPTIONS
       -c yaml_location, --config=yaml_location
@@ -100,7 +100,7 @@ Transforming data is performed by extractors described in XML (e.g. [domain-extr
 
 Run the job:
     
-    java -jar sync-files-database/target/sync-files-database-1.0-SNAPSHOT.jar --config=sync-files-database/config.yml --exec --job=sync
+    java -jar sync-files-database/target/sync-files-database-2.0.jar --config=sync-files-database/config.yml --exec --job=sync
 
 Result - data successfully inserted into the database:
 

--- a/sync-files-database/pom.xml
+++ b/sync-files-database/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.bootique.linkmove.demo</groupId>
         <artifactId>bootique-linkmove-demo</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>2.0</version>
     </parent>
 
     <artifactId>sync-files-database</artifactId>
@@ -18,7 +18,7 @@
     </description>
 
     <properties>
-        <linkmove-version>2.6</linkmove-version>
+        <linkmove-version>2.9</linkmove-version>
         <derby-version>10.14.2.0</derby-version>
         <mysql-version>8.0.13</mysql-version>
 
@@ -30,7 +30,7 @@
             <dependency>
                 <groupId>io.bootique.bom</groupId>
                 <artifactId>bootique-bom</artifactId>
-                <version>1.0.RC1</version>
+                <version>2.0-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/sync-files-database/src/main/java/Application.java
+++ b/sync-files-database/src/main/java/Application.java
@@ -1,10 +1,10 @@
-import com.google.inject.Binder;
-import com.google.inject.Module;
+import io.bootique.BaseModule;
 import io.bootique.Bootique;
+import io.bootique.di.Binder;
 import io.bootique.job.runtime.JobModule;
 import io.bootique.linkmove.LinkMoveModule;
 
-public class Application implements Module {
+public class Application extends BaseModule {
 
     public static void main(String[] args) {
         Bootique.app(args)

--- a/sync-files-database/src/main/java/LmStackExtendCallBack.java
+++ b/sync-files-database/src/main/java/LmStackExtendCallBack.java
@@ -1,13 +1,11 @@
-import com.google.inject.Inject;
 import com.nhl.link.move.connect.StreamConnector;
 import com.nhl.link.move.runtime.LmRuntimeBuilder;
-import io.bootique.jdbc.DataSourceFactory;
 import io.bootique.linkmove.LinkMoveBuilderCallback;
 import io.bootique.resource.ResourceFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
+import java.util.Map;
 
 public class LmStackExtendCallBack implements LinkMoveBuilderCallback {
 
@@ -16,7 +14,7 @@ public class LmStackExtendCallBack implements LinkMoveBuilderCallback {
 
         builder.withConnector("domainSourceConnector", new StreamConnector() {
             @Override
-            public InputStream getInputStream() throws IOException {
+            public InputStream getInputStream(Map<String, ?> var1) throws IOException {
                 return ResourceFactory.class.getClassLoader().getResource("etl/domain.json").openStream();
             }
 

--- a/sync-files-database/src/main/java/SyncJob.java
+++ b/sync-files-database/src/main/java/SyncJob.java
@@ -1,4 +1,3 @@
-import com.google.inject.Inject;
 import com.nhl.link.move.Execution;
 import com.nhl.link.move.LmTask;
 import com.nhl.link.move.runtime.LmRuntime;
@@ -9,6 +8,7 @@ import io.bootique.lm.cayenne.SArticle;
 import io.bootique.lm.cayenne.SDomain;
 import io.bootique.lm.cayenne.STag;
 
+import javax.inject.Inject;
 import java.util.Map;
 
 public class SyncJob extends BaseJob {

--- a/sync-files-database/src/main/resources/etl/article-extractor.xml
+++ b/sync-files-database/src/main/resources/etl/article-extractor.xml
@@ -24,7 +24,7 @@
             </attribute>
         </attributes>
         <properties>
-            <extractor.csv.delimiter>;</extractor.csv.delimiter>
+            <extractor.csv.delimiter>,</extractor.csv.delimiter>
             <extractor.csv.readFrom>2</extractor.csv.readFrom>
         </properties>
     </extractor>

--- a/sync-files-database/src/main/resources/etl/article.csv
+++ b/sync-files-database/src/main/resources/etl/article.csv
@@ -1,4 +1,4 @@
-Id;Title;Body;Domain_ID;
-1;About;ObjectStyle has deep roots in the open source community...;1;
-2;Getting Started with Bootique;Getting Started with Bootique...;2;
-3;LinkMove;LinkMove  an ETL solution...;3;
+Id,Title,Body,Domain_ID
+1,About,ObjectStyle has deep roots in the open source community...,1
+2,Getting Started with Bootique,Getting Started with Bootique...,2
+3,LinkMove,LinkMove an ETL solution...,3

--- a/sync-files-database/src/main/resources/etl/tag-extractor.xml
+++ b/sync-files-database/src/main/resources/etl/tag-extractor.xml
@@ -24,7 +24,7 @@
             </attribute>
         </attributes>
         <properties>
-            <extractor.csv.delimiter>;</extractor.csv.delimiter>
+            <extractor.csv.delimiter>,</extractor.csv.delimiter>
             <extractor.csv.readFrom>3</extractor.csv.readFrom>
         </properties>
     </extractor>

--- a/sync-files-database/src/main/resources/etl/tag.csv
+++ b/sync-files-database/src/main/resources/etl/tag.csv
@@ -1,5 +1,4 @@
-Id;Name;Article_ID;color
-Id;Name;Article_ID;color
-1;ObjectStyle;1;black
-2;Bootique;2;green
-3;LinkMove;3;blue
+Id,Name,Article_ID,color
+1,ObjectStyle,1,black
+2,Bootique,2,green
+3,LinkMove,3,blue


### PR DESCRIPTION
Changed project version to 2.0 and Application class extends BaseModule. bootique-bom updated to 2.0-SNAPSHOT. linkmove-version updated to 2.9.
In sync-database SyncJob class, the getMerged() method returns a DataFrame and SourceTargetPair is not in 2.0-SNAPSHOT version, so the fixArticles() method updated.
Jar file name changed in README.